### PR TITLE
Remove hardcoded OS X/Windows version strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Vlc Cookbook CHANGELOG
 
 v?.?.? (????-??-??)
 -------------------
+- Remove hardcoded version strings in OS X and Windows providers; get latest
+  version from the VLC site during the Chef run
 
 v0.1.0 (2015-06-20)
 -------------------

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,68 @@
+# Encoding: UTF-8
+#
+# Cookbook Name:: vlc
+# Library:: helpers
+#
+# Copyright 2015 Jonathan Hartman
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'net/http'
+
+module Vlc
+  # A set of helper methods for the vlc cookbook.
+  #
+  # @author Jonathan Hartman <j@p4nt5.com>
+  module Helpers
+    #
+    # Sort the list of available VLC versions and return the newest one.
+    #
+    # @return [String] the latest VLC version
+    #
+    def latest_version
+      @latest_version ||= begin
+        versions.map { |v| Gem::Version.new(v) }.sort.last.to_s
+      end
+    end
+
+    #
+    # Find all the valid version strings in the VLD download page's HTML.
+    #
+    # @return [Array] an array of version strings
+    #
+    def versions
+      @versions ||= begin
+        vlc_site_body.lines.map do |l|
+          match = l.match(%r{^<a href="([0-9]+\.[0-9]+\.[0-9]+)/">})
+          match && match[1]
+        end.compact
+      end
+    end
+
+    #
+    # Get the VLC download directory page and save it for later processing.
+    #
+    # @return [String] the HTML site body
+    #
+    def vlc_site_body
+      @vlc_site_body ||= begin
+        # PSA: A 301 is returned if the ending / is missing from the URL
+        u = URI.parse('https://get.videolan.org/vlc/')
+        opts = { use_ssl: u.scheme == 'https',
+                 ca_file: Chef::Config[:ssl_ca_file] }
+        Net::HTTP.start(u.host, u.port, opts) { |h| h.get(u) }.body
+      end
+    end
+  end
+end

--- a/libraries/provider_vlc_app.rb
+++ b/libraries/provider_vlc_app.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 
+require 'net/http'
 require 'chef/provider/lwrp_base'
 require_relative 'resource_vlc_app'
 require_relative 'provider_vlc_app_debian'

--- a/libraries/provider_vlc_app_mac_os_x.rb
+++ b/libraries/provider_vlc_app_mac_os_x.rb
@@ -19,6 +19,7 @@
 #
 
 require 'chef/provider/lwrp_base'
+require_relative 'helpers'
 require_relative 'provider_vlc_app'
 
 class Chef
@@ -28,8 +29,9 @@ class Chef
       #
       # @author Jonathan Hartman <j@p4nt5.com>
       class MacOsX < VlcApp
-        URL ||= 'http://get.videolan.org/vlc/2.2.1/macosx/vlc-2.2.1.dmg'
         PATH ||= '/Applications/VLC.app'
+
+        include Vlc::Helpers
 
         private
 
@@ -41,8 +43,9 @@ class Chef
         # (see VlcApp#install!)
         #
         def install!
+          s = remote_path
           dmg_package 'VLC' do
-            source URL
+            source s
             volumes_dir 'vlc-2.2.1'
             action :install
           end
@@ -64,6 +67,16 @@ class Chef
               action :delete
             end
           end
+        end
+
+        #
+        # Use the version helper methods to construct a remote download URL.
+        #
+        # @return [String] a download URL
+        #
+        def remote_path
+          "https://get.videolan.org/vlc/#{latest_version}/macosx/" \
+            "vlc-#{latest_version}.dmg"
         end
       end
     end

--- a/libraries/provider_vlc_app_windows.rb
+++ b/libraries/provider_vlc_app_windows.rb
@@ -19,6 +19,7 @@
 #
 
 require 'chef/provider/lwrp_base'
+require_relative 'helpers'
 require_relative 'provider_vlc_app'
 
 class Chef
@@ -28,8 +29,9 @@ class Chef
       #
       # @author Jonathan Hartman <j@p4nt5.com>
       class Windows < VlcApp
-        URL ||= 'http://get.videolan.org/vlc/2.2.1/win64/vlc-2.2.1-win64.exe'
         PATH ||= ::File.expand_path('/Program Files/VideoLAN/VLC')
+
+        include Vlc::Helpers
 
         private
 
@@ -70,8 +72,9 @@ class Chef
         # Use a remote_file resource to download the package.
         #
         def download_package
+          s = remote_path
           remote_file download_path do
-            source URL
+            source s
             action :create
             only_if { !::File.exist?(PATH) }
           end
@@ -80,10 +83,21 @@ class Chef
         #
         # Construct a download destination under Chef's cache dir.
         #
-        # @return [String]
+        # @return [String] a local file path
         #
         def download_path
-          ::File.join(Chef::Config[:file_cache_path], ::File.basename(URL))
+          ::File.join(Chef::Config[:file_cache_path],
+                      ::File.basename(remote_path))
+        end
+
+        #
+        # Use the version helper methods to construct a remote download URL.
+        #
+        # @return [String] a download URL
+        #
+        def remote_path
+          "https://get.videolan.org/vlc/#{latest_version}/win64/" \
+            "vlc-#{latest_version}-win64.exe"
         end
       end
     end

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -1,0 +1,61 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+require_relative '../../libraries/helpers'
+
+describe Vlc::Helpers do
+  let(:test_class) do
+    Class.new do
+      include Vlc::Helpers
+    end
+  end
+  let(:test_obj) { test_class.new }
+
+  describe '#latest_version' do
+    it 'returns the most recent version string' do
+      o = test_obj
+      allow(o).to receive(:versions).and_return(%w(0.1.1 1.0.1 1.0.10 1.0.9))
+      expect(o.latest_version).to eq('1.0.10')
+    end
+  end
+
+  describe '#versions' do
+    let(:vlc_site_body) do
+      <<-EOH.gsub(/^ +/, '')
+        <html>
+        <head><title>Index of /videolan/vlc/</title></head>
+        <body bgcolor="white">
+        <h1>Index of /videolan/vlc/</h1><hr><pre><a href="../">../</a>
+        <a href="0.1.99/">0.1.99/</a>        18-Aug-2010 20:56               -
+        <a href="0.1.99a/">0.1.99a/</a>      18-Aug-2010 20:56               -
+        <a href="0.1.99b/">0.1.99b/</a>      18-Aug-2010 20:56               -
+        <a href="2.2.1/">2.2.1/</a>          16-Apr-2015 14:44               -
+        <a href="eyetv/">eyetv/</a>          09-Feb-2012 12:50               -
+        <a href="ipkg-feed/">ipkg-feed/</a>  18-Aug-2010 21:05               -
+        <a href="last/">last/</a>            27-Feb-2015 16:51               -
+        </pre><hr></body>
+        </html>
+      EOH
+    end
+
+    it 'returns an array of version strings' do
+      o = test_obj
+      allow(o).to receive(:vlc_site_body).and_return(vlc_site_body)
+      expect(o.versions).to eq(%w(0.1.99 2.2.1))
+    end
+  end
+
+  describe '#vlc_site_body' do
+    let(:body) { 'a site body' }
+
+    before(:each) do
+      allow(Net::HTTP).to receive(:start)
+        .with('get.videolan.org', 443, use_ssl: true, ca_file: nil)
+        .and_return(double(body: body))
+    end
+
+    it 'returns the site body' do
+      expect(test_obj.vlc_site_body).to eq(body)
+    end
+  end
+end


### PR DESCRIPTION
The only version listings I could find were in the HTML on their download page but :meh:
