### PR TITLE
Add AppVeyor and CircleCI builds

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -3,4 +3,4 @@ driver:
   name: localhost
 
 platforms:
-  - name: macosx
+  - name: windows

--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -1,6 +1,7 @@
 ---
 driver:
   name: localhost
+  clean_up_on_destroy: false
 
 platforms:
   - name: windows

--- a/.kitchen.circle.yml
+++ b/.kitchen.circle.yml
@@ -1,0 +1,8 @@
+---
+driver:
+  name: docker
+
+platforms:
+  - name: ubuntu-15.04
+  - name: ubuntu-14.04
+  - name: debian-8.1

--- a/.kitchen.travis.yml
+++ b/.kitchen.travis.yml
@@ -1,6 +1,7 @@
 ---
 driver:
   name: localhost
+  clean_up_on_destroy: false
 
 platforms:
   - name: macosx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,21 @@
 language: objective-c
 
+branches:
+  only:
+    - master
+
 install:
   - curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -P chefdk
-  - chef exec bundle install --without=development integration
+  - chef exec bundle update
 
 before_script:
   # Pending ENV support in Kitchen's Rake tasks and not just the CLI
   - cp .kitchen.travis.yml .kitchen.local.yml
-  - echo -e $DIGITALOCEAN_SSH_KEY_BODY > ~/.ssh/id_rsa
 
 script:
-  - chef exec rake && chef exec kitchen test -c 5
+  - chef exec bundle exec kitchen test -c 2
 
 after_script:
-  - chef exec kitchen destroy
 
 env:
   global:

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :test do
   gem 'fauxhai'
   gem 'test-kitchen'
   gem 'kitchen-digitalocean', '>= 0.8.0'
+  gem 'kitchen-docker'
   gem 'kitchen-localhost'
   gem 'kitchen-vagrant'
   gem 'winrm-transport'

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 Vlc Cookbook
 ============
 [![Cookbook Version](https://img.shields.io/cookbook/v/vlc.svg)][cookbook]
-[![Build Status](https://img.shields.io/travis/RoboticCheese/vlc-chef.svg)][travis]
+[![Linux Build Status](https://img.shields.io/circleci/project/RoboticCheese/vlc-chef.svg)][circle]
+[![OS X Build Status](https://img.shields.io/travis/RoboticCheese/vlc-chef.svg)][travis]
+[![Windows Build Status](https://img.shields.io/appveyor/ci/RoboticCheese/vlc-chef.svg)][appveyor]
 [![Code Climate](https://img.shields.io/codeclimate/github/RoboticCheese/vlc-chef.svg)][codeclimate]
 [![Coverage Status](https://img.shields.io/coveralls/RoboticCheese/vlc-chef.svg)][coveralls]
 
 [cookbook]: https://supermarket.chef.io/cookbooks/vlc
+[circle]: https://circleci.com/gh/RoboticCheese/vlc-chef
+[appveyor]: https://ci.appveyor.com/project/RoboticCheese/vlc-chef
 [travis]: https://travis-ci.org/RoboticCheese/vlc-chef
 [codeclimate]: https://codeclimate.com/github/RoboticCheese/vlc-chef
 [coveralls]: https://coveralls.io/r/RoboticCheese/vlc-chef

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+branches:
+  only:
+    - master
+
+cache:
+  - '%TEMP%\verifier\gems'
+
+install:
+  - cinst chefdk
+  - SET PATH=C:\opscode\chefdk\bin;%PATH%
+
+build_script:
+  - chef exec bundle update
+  - copy .kitchen.appveyor.yml .kitchen.local.yml
+
+test_script:
+  - chef exec bundle exec kitchen test -c 2

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,24 @@
+machine:
+  ruby:
+    version: 2.1.6
+  services:
+    - docker
+
+dependencies:
+  pre:
+    - rvm install 2.0.0-p645
+    - rvm install 1.9.3-p545
+  override:
+    - bundle update
+    - rvm-exec 2.0.0-p645 bundle update
+    - rvm-exec 1.9.3-p545 bundle update
+  cache_directories:
+    - /home/ubuntu/.rvm/gems
+
+test:
+  pre:
+    - cp .kitchen.circle.yml .kitchen.local.yml
+  override:
+    - bundle exec rake
+    - rvm-exec 2.0.0-p645 bundle exec rake
+    - bundle exec kitchen verify -c 3

--- a/circle.yml
+++ b/circle.yml
@@ -7,11 +7,9 @@ machine:
 dependencies:
   pre:
     - rvm install 2.0.0-p645
-    - rvm install 1.9.3-p545
   override:
     - bundle update
     - rvm-exec 2.0.0-p645 bundle update
-    - rvm-exec 1.9.3-p545 bundle update
   cache_directories:
     - /home/ubuntu/.rvm/gems
 

--- a/test/integration/uninstall/serverspec/spec_helper.rb
+++ b/test/integration/uninstall/serverspec/spec_helper.rb
@@ -1,1 +1,10 @@
-../../default/serverspec/spec_helper.rb
+# Encoding: UTF-8
+
+require 'serverspec'
+
+if RUBY_PLATFORM.match(/mswin|mingw32|windows/)
+  set :os, family: 'windows'
+  set :backend, :cmd
+else
+  set :backend, :exec
+end


### PR DESCRIPTION
New build layout:
- TravisCI for OS X via Objective-C environment + kitchen-localhost
- AppVeyor for Windows via kitchen-localhost
- CircleCI for unit tests over multiple Rubies + *nix via kitchen-docker
